### PR TITLE
Updated HLS port-protocol Subscribe Proxy Example

### DIFF
--- a/src/page/test/subscribeStreamManagerProxy/index.js
+++ b/src/page/test/subscribeStreamManagerProxy/index.js
@@ -161,8 +161,8 @@
     })
     var hlsConfig = Object.assign({}, config, {
       host: serverAddress,
-      protocol: protocol,
-      port: isSecure ? serverSettings.hlssport : serverSettings.hlsport,
+      protocol: 'http',
+      port: serverSettings.hlsport,
       streamName: config.stream1,
       mimeType: 'application/x-mpegURL'
     })


### PR DESCRIPTION
+ Forced protocol to 'http'
+ Forced port to default http (non-secure)