### PR TITLE
disallowing audio contraint when iPod detected.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "red5pro-html-sdk-testbed",
-  "version": "4.5.1",
-
+  "version": "4.5.3",
   "description": "Testbed examples for Red5 Pro HTML SDK",
   "main": "src/js/index.js",
   "repository": {

--- a/static/script/testbed-config.js
+++ b/static/script/testbed-config.js
@@ -24,6 +24,7 @@
 
   var isMoz = !!navigator.mozGetUserMedia;
   var isEdge = adapter && adapter.browserDetails.browser.toLowerCase() === 'edge';
+  var isiPod = !!navigator.platform && /iPod/.test(navigator.platform);
   var config = sessionStorage.getItem('r5proTestBed');
   var json;
   var serverSettings = {
@@ -57,7 +58,7 @@
       "useAudio": true,
       "useVideo": true,
       "mediaConstraints": {
-        "audio": true,
+        "audio": isiPod ? false : true,
         "video": (isMoz || isEdge) ? true : {
           "width": {
             "min": 320,


### PR DESCRIPTION
Nothing we can do about allowing `audio` constrain for `gUM` on iPod. Not sure why it is disallowed, most likely to promote FaceTime.