### PR TITLE
Verify stream manager api result

### DIFF
--- a/src/page/test/subscribeStreamManagerProxy/index.js
+++ b/src/page/test/subscribeStreamManagerProxy/index.js
@@ -117,7 +117,12 @@
             }
           })
           .then(function (json) {
-            resolve(json.serverAddress);
+            if(json.serverAddress && json.serverAddress !== 'NONE') {
+              resolve(json.serverAddress);
+            }
+            else {
+              throw new TypeError('Could not get edge ip.');
+            }
           })
           .catch(function (error) {
             var jsonError = typeof error === 'string' ? error : JSON.stringify(error, null, 2)


### PR DESCRIPTION
If there is no broadcast on current stream or api return "NONE" we return an `Exception`.