### PR TITLE
Verify if targetSubscriber is defined before unload

### DIFF
--- a/src/page/test/subscribeStreamManagerProxy/index.js
+++ b/src/page/test/subscribeStreamManagerProxy/index.js
@@ -252,13 +252,13 @@
 
   // Clean up.
   window.addEventListener('beforeunload', function() {
-    function clearRefs () {
-      if (targetSubscriber) {
+    if (targetSubscriber) {
+      function clearRefs () {
         targetSubscriber.off('*', onSubscriberEvent);
+        targetSubscriber = undefined;
       }
-      targetSubscriber = undefined;
+      unsubscribe().then(clearRefs).catch(clearRefs);
     }
-    unsubscribe().then(clearRefs).catch(clearRefs);
   });
 
 })(this, document, window.red5prosdk);


### PR DESCRIPTION
If stream doesn't start before unload, `targetSubscribe` isn't define and `unsubscribe()` will throw an exception.