### PR TITLE
Correct the pass of auth params in proxy tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red5pro-html-sdk-testbed",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "description": "Testbed examples for Red5 Pro HTML SDK",
   "main": "src/js/index.js",
   "repository": {

--- a/src/page/sm-test/publishStreamManagerProxy/index.js
+++ b/src/page/sm-test/publishStreamManagerProxy/index.js
@@ -179,7 +179,9 @@
                         });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if(window.query('view')) {
       publishOrder = [window.query('view')];

--- a/src/page/sm-test/publishStreamManagerProxyCamera/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyCamera/index.js
@@ -230,7 +230,10 @@
                         });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
+
 
     if(window.query('view')) {
       publishOrder = [window.query('view')];

--- a/src/page/sm-test/publishStreamManagerProxyMultiOriginRequest/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyMultiOriginRequest/index.js
@@ -179,10 +179,9 @@
                         });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
-
-    // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if(window.query('view')) {
       publishOrder = [window.query('view')];

--- a/src/page/sm-test/publishStreamManagerProxyMultiOriginStrictRequest/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyMultiOriginStrictRequest/index.js
@@ -179,7 +179,9 @@
                         });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if(window.query('view')) {
       publishOrder = [window.query('view')];

--- a/src/page/sm-test/publishStreamManagerProxyRecord/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyRecord/index.js
@@ -180,7 +180,9 @@
                         });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if(window.query('view')) {
       publishOrder = [window.query('view')];

--- a/src/page/sm-test/publishStreamManagerProxyRegionRequest/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyRegionRequest/index.js
@@ -179,7 +179,9 @@
                         });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if(window.query('view')) {
       publishOrder = [window.query('view')];

--- a/src/page/sm-test/publishStreamManagerProxyRegionStrictRequest/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyRegionStrictRequest/index.js
@@ -179,7 +179,9 @@
                         });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if(window.query('view')) {
       publishOrder = [window.query('view')];

--- a/src/page/sm-test/publishStreamManagerProxyScreenShare/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyScreenShare/index.js
@@ -240,6 +240,11 @@
         audio: parseInt(bandwidthAudioField.value)
       }
     });
+
+    audioConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      audioConfig.connectionParams);
+
     new red5prosdk.RTCPublisher()
       .init(audioConfig)
       .then(function (publisherImpl) {
@@ -304,6 +309,10 @@
                           return navigator.mediaDevices.getUserMedia(c);
                         }
                     });
+
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     new red5prosdk.RTCPublisher()
       .init(rtcConfig)

--- a/src/page/sm-test/publishStreamManagerProxySettings/index.js
+++ b/src/page/sm-test/publishStreamManagerProxySettings/index.js
@@ -192,7 +192,9 @@
                         });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if(window.query('view')) {
       publishOrder = [window.query('view')];

--- a/src/page/sm-test/publishStreamManagerProxyTranscoderPOST/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyTranscoderPOST/index.js
@@ -260,7 +260,9 @@
                         });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if(window.query('view')) {
       publishOrder = [window.query('view')];

--- a/src/page/sm-test/subscribeBackupStreamSwitchStreammanager/index.js
+++ b/src/page/sm-test/subscribeBackupStreamSwitchStreammanager/index.js
@@ -254,7 +254,11 @@
         },
         streamName: edgeList[i].name
       });
-      subConfig.connectionParams = Object.assign(getAuthenticationParams(), subConfig.connectionParams);
+
+      subConfig.connectionParams = Object.assign({}, 
+        getAuthenticationParams().connectionParams,
+        subConfig.connectionParams);
+
       generateSubscriber(subConfig)
         .then(onSubscriberResolve(id))
         .catch(handleGenerateSubscriberError);

--- a/src/page/sm-test/subscribeStreamManagerProxy/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxy/index.js
@@ -208,7 +208,9 @@
     });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if (!config.useVideo) {
       rtcConfig.videoEncoding = 'NONE';

--- a/src/page/sm-test/subscribeStreamManagerProxyScreenShare/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyScreenShare/index.js
@@ -217,6 +217,10 @@
       streamName: name
     });
 
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
+
     new red5prosdk.RTCSubscriber()
       .init(rtcConfig)
       .then(function (subscriberImpl) {
@@ -279,6 +283,10 @@
       streamName: name + '_audio',
       mediaElementId: 'red5pro-audio'
     });
+
+    audioConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      audioConfig.connectionParams);
 
     new red5prosdk.RTCSubscriber()
       .init(audioConfig)

--- a/src/page/sm-test/subscribeStreamManagerProxyTranscoderRTC/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyTranscoderRTC/index.js
@@ -211,7 +211,9 @@
     });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if (!config.useVideo) {
       rtcConfig.videoEncoding = 'NONE';

--- a/src/page/sm-test/subscribeStreamManagerProxyVP8/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyVP8/index.js
@@ -178,7 +178,9 @@
     });
 
     // Merge in possible authentication params.
-    rtcConfig.connectionParams = Object.assign(getAuthenticationParams(), rtcConfig.connectionParams);
+    rtcConfig.connectionParams = Object.assign({}, 
+      getAuthenticationParams().connectionParams,
+      rtcConfig.connectionParams);
 
     if (!config.useVideo) {
       rtcConfig.videoEncoding = 'NONE';


### PR DESCRIPTION
The authentication params were improperly attributed in the proxy connection for publishers and subscribers when using the authentication fields in the Settings.