### PR TITLE
Bug/browsers video mute rpro 6189

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red5pro-html-sdk-testbed",
-  "version": "5.5.0-RC9",
+  "version": "5.5.0-RC10",
   "description": "Testbed examples for Red5 Pro HTML SDK",
   "main": "src/js/index.js",
   "repository": {

--- a/src/page/test/publishMute/index.html
+++ b/src/page/test/publishMute/index.html
@@ -13,7 +13,7 @@
       {{> status-field-publisher}}
       {{> statistics-field}}
       <div class="centered">
-        <video id="red5pro-publisher" controls autoplay playsinline muted></video>
+        <video id="red5pro-publisher" autoplay playsinline muted></video>
       </div>
       <div class="centered">
         <button id="mute-audio-button">mute audio</button>

--- a/src/page/test/subscribeVideoMute/README.md
+++ b/src/page/test/subscribeVideoMute/README.md
@@ -1,0 +1,156 @@
+# Subscribe Failover using Red5 Pro
+
+This is an example of utilizing the failover mechanism of the Red5 Pro HTML SDK to select a subscriber based on browser support.
+
+The default failover order is:
+
+1. WebRTC
+2. RTMP/Flash
+3. HLS
+
+When utilizing the auto-failover mechanism, the SDK - by default - will first test for WebRTC support and if missing will attempt to embed a subscriber SWF for the broadcast. If Flash is not supported in the browser, it will finally attempt to playback using HLS.
+
+You can define the desired failover order from using `setPlaybackOrder`.
+
+> For more detailed information on Configuring and Subscribing with the Red5 Pro SDK, please visit the [Red5 Pro Documentation](https://www.red5pro.com/docs/streaming/subscriber.html).
+
+## Example Code
+- **[index.html](index.html)**
+- **[index.js](index.js)**
+
+# How to Subscribe
+
+Subscribing to a Red5 Pro stream requires a few components to function fully.
+
+> The examples in this repo also utilize various es2015 shims and polyfills to support ease in such things as `Object.assign` and `Promises`. You can find the list of these utilities used in [https://github.com/red5pro/streaming-html5/tree/master/static/lib/es6](feature/update_docs_RPRO-5153).
+
+## Including the SDK
+
+You will need to include the Red5 Pro SDK library on the page. If you have not already done so, download the Red5 Pro HTML SDK from your account page: [https://account.red5pro.com/download](https://account.red5pro.com/download).
+
+Once downloaded, unzip and move the library files - contained in the `lib` directory of the unzipped download - that makes sens for your project. _For the purposes of these examples, we have maked the entire `lib` directory into the top level of our project._
+
+Once the required SDK files are provided and loaded on the page, the root of the library is accessible from `window.red5prosdk`:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <title>Red5 Pro Subscriber</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport">
+    <!-- Recommended shim for WebRTC. -->
+    <script src="//webrtc.github.io/adapter/adapter-latest.js"></script>
+    <!-- Recommended shim for fullscreen support. -->
+    <script src="lib/screenfull/screenfull.min.js"></script>
+    <!-- CSS file included with Red5 Pro SDK to style playback controls of the target video element. -->
+    <link rel="stylesheet" href="lib/red5pro/red5pro-media.css">
+  </head>
+  <body>
+    <!-- Target video element to playback stream. -->
+    <video id="red5pro-subscriber"
+      autoplay controls playsinline
+      class="red5pro-media red5pro-media-background"
+      width="640" height="480"></video>
+    <!-- Red5 Pro SDK library. -->
+    <script src="lib/red5pro/red5pro.min.sdk"></script>
+    <!-- The client code... -->
+    <script>
+      (function (window, red5pro) {
+
+        // Turn on debugging, to be shown in the Dev Console.
+        red5pro.setLogger(red5pro.LOG_LEVELS.DEBUG);
+
+        // Continue with your code, more examples below.
+
+      })(window, window.red5prosdk);
+    </script>
+  </body>
+</html>
+```
+
+## Subscriber Selection & Initialization
+
+A Subscriber instance is required to attach a stream and request subscription. The SDK can determine browser support and instantiate the proper Subscriber implementation based on the desired failover order.
+
+The available Playback Techs supported by the Red5 Pro SDK are:
+
+* WebRTC
+* Flash/RTMP
+* HLS
+
+> *NOTE*: Aside from the recommendation to utilize the [adapter.js](https://github.com/webrtc/adapter) library to "shim" similar functionality across WebRTC-supported browesers, the Red5 Pro SDK itself does not provide any polyfills for support. As such, the SDK checks the inherent support of the browser in its failover process. For example, if your browser does not inherently support HLS (most browsers aside from Desktop and Mobile Safari), then you will need to use a 3rd Party library in order to provide such support.
+
+When requesting to playback a stream using failover, you will need to provide an initialization configuration for each desired tech. To do so, provide a `rtc`, a `rtmp` and a `hls` configuration property within the configuraiton object passed through `init()` invocation:
+
+```js
+var config = {
+  rtcport: 5080,
+  rtmpport: 1935,
+  hlsport: 5080
+};
+var rtcConfig = Object.assign({}, config, {
+  protocol: 'ws',
+  port: config.rtcport,
+  subscriptionId: 'subscriber-' + instanceId,
+  streamName: config.stream1
+})
+var rtmpConfig = Object.assign({}, config, {
+  protocol: 'rtmp',
+  port: config.rtmpport,
+  streamName: config.stream1,
+  swf: 'lib/red5pro/red5pro-subscriber.swf',
+  swfobjectURL: 'lib/swfobject/swfobject.js',
+  productInstallURL: 'lib/swfobject/playerProductInstall.swf'
+})
+var hlsConfig = Object.assign({}, config, {
+  protocol: 'http',
+  port: config.hlsport,
+  streamName: config.stream1,
+  mimeType: 'application/x-mpegURL'
+})
+
+var subscriber = new red5pro.Red5ProSubscriber();
+subscriber.setPlaybackOrder(subscribeOrder)
+  .init({
+    rtc: rtcConfig,
+    rtmp: rtmpConfig,
+    hls: hlsConfig
+  })
+  .then(function (selectedSubscriber) {
+    // We have successfully found a playback tech from the list...
+  });
+```
+
+[index.js #97](index.js#L97)
+
+The `init` method of the `Red5ProSubscriber` returns a `Promise`-like object that will be resolved with the instantiated Subscriber implementation based on the subscriber order and browser support.
+
+You can determine the selected implementation by invoking `selectedSubscriber.getType()`.
+
+> Read more about configurations and their attributes from the [Red5 Pro HTML SDK Documentation](https://github.com/infrared5/red5pro-html-sdk#subscriber).
+
+### Subscribing
+
+The `init` method of the `Red5ProSubscriber` instance returns a `Promise`-object which, when resolved, relays the Subscriber instance determined from the failover. To start a subscribing session, call the `subscribe` method of the Subscriber resolved:
+
+```js
+subscriber.setPlaybackOrder(subscribeOrder)
+  .init({
+    rtc: rtcConfig,
+    rtmp: rtmpConfig,
+    hls: hlsConfig
+  })
+  .then(function (selectedSubscriber) {
+    return selectedSubscriber.subscribe();
+  })
+  .then(function () {
+    console.log('Successfully started a subscription session!');
+  })
+  .catch(function () {
+    console.error('Could not start a subscription session: ' + error);
+  })
+```
+
+[index.js #136](index.js#L136)
+

--- a/src/page/test/subscribeVideoMute/README.md
+++ b/src/page/test/subscribeVideoMute/README.md
@@ -1,156 +1,20 @@
-# Subscribe Failover using Red5 Pro
+# Subscribe Video Mute
 
-This is an example of utilizing the failover mechanism of the Red5 Pro HTML SDK to select a subscriber based on browser support.
+The intent of this test is to demonstrate subscribing to a broadcast which has its video stream "muted". We have noticed that in Chrome and Safari browsers, when trying to play back a stream that has both Audio and Video tracks, but the Video tracks are empty - because the broadcaster has turned off their Camer - that no playback occurs when assigning the `MediaStream` source to a `<video>` element. Presumably, this is because the Video track playback drives the `<video>` element through its lifecycle events for `canplay` and `loadeddata`.
 
-The default failover order is:
+As such, you may require adding an additional `<audio>` element to the page to allow for the audio to playback while the initial Camera stream is "muted". Playback of a `MediaStream` with audio flowing and video "muted" is acceptable in said browsers using an `<audio>` element.
+In this test, we listen for the `Subscribe.Metadata` event and check if the initial `streamingMode` property on the metadata is set to `Audio`. In such a case, it means that the broadcaster has muted their video stream. As such, the test starts subscribing to the stream in an `audio` element to allow for audio playback.
 
-1. WebRTC
-2. RTMP/Flash
-3. HLS
+When the `streamingMode` property changes to `Video/Audio`, the video stream has become unmuted.
 
-When utilizing the auto-failover mechanism, the SDK - by default - will first test for WebRTC support and if missing will attempt to embed a subscriber SWF for the broadcast. If Flash is not supported in the browser, it will finally attempt to playback using HLS.
+# Notes
 
-You can define the desired failover order from using `setPlaybackOrder`.
+Somethings of note:
 
-> For more detailed information on Configuring and Subscribing with the Red5 Pro SDK, please visit the [Red5 Pro Documentation](https://www.red5pro.com/docs/streaming/subscriber.html).
+* Playback will only work when navigating to this test page after clicking it from the testbed listing. 
 
-## Example Code
-- **[index.html](index.html)**
-- **[index.js](index.js)**
+This is because the `autoplay` restriction is not enforced since you interacted with the page. If you load this test using a *Refresh*, the `autoplay` restriction will be in affect and the audio playback in the `audio` element will additionally be muted.
 
-# How to Subscribe
+* This test does not work so well in Safari
 
-Subscribing to a Red5 Pro stream requires a few components to function fully.
-
-> The examples in this repo also utilize various es2015 shims and polyfills to support ease in such things as `Object.assign` and `Promises`. You can find the list of these utilities used in [https://github.com/red5pro/streaming-html5/tree/master/static/lib/es6](feature/update_docs_RPRO-5153).
-
-## Including the SDK
-
-You will need to include the Red5 Pro SDK library on the page. If you have not already done so, download the Red5 Pro HTML SDK from your account page: [https://account.red5pro.com/download](https://account.red5pro.com/download).
-
-Once downloaded, unzip and move the library files - contained in the `lib` directory of the unzipped download - that makes sens for your project. _For the purposes of these examples, we have maked the entire `lib` directory into the top level of our project._
-
-Once the required SDK files are provided and loaded on the page, the root of the library is accessible from `window.red5prosdk`:
-
-```html
-<!doctype html>
-<html>
-  <head>
-    <title>Red5 Pro Subscriber</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-    <meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport">
-    <!-- Recommended shim for WebRTC. -->
-    <script src="//webrtc.github.io/adapter/adapter-latest.js"></script>
-    <!-- Recommended shim for fullscreen support. -->
-    <script src="lib/screenfull/screenfull.min.js"></script>
-    <!-- CSS file included with Red5 Pro SDK to style playback controls of the target video element. -->
-    <link rel="stylesheet" href="lib/red5pro/red5pro-media.css">
-  </head>
-  <body>
-    <!-- Target video element to playback stream. -->
-    <video id="red5pro-subscriber"
-      autoplay controls playsinline
-      class="red5pro-media red5pro-media-background"
-      width="640" height="480"></video>
-    <!-- Red5 Pro SDK library. -->
-    <script src="lib/red5pro/red5pro.min.sdk"></script>
-    <!-- The client code... -->
-    <script>
-      (function (window, red5pro) {
-
-        // Turn on debugging, to be shown in the Dev Console.
-        red5pro.setLogger(red5pro.LOG_LEVELS.DEBUG);
-
-        // Continue with your code, more examples below.
-
-      })(window, window.red5prosdk);
-    </script>
-  </body>
-</html>
-```
-
-## Subscriber Selection & Initialization
-
-A Subscriber instance is required to attach a stream and request subscription. The SDK can determine browser support and instantiate the proper Subscriber implementation based on the desired failover order.
-
-The available Playback Techs supported by the Red5 Pro SDK are:
-
-* WebRTC
-* Flash/RTMP
-* HLS
-
-> *NOTE*: Aside from the recommendation to utilize the [adapter.js](https://github.com/webrtc/adapter) library to "shim" similar functionality across WebRTC-supported browesers, the Red5 Pro SDK itself does not provide any polyfills for support. As such, the SDK checks the inherent support of the browser in its failover process. For example, if your browser does not inherently support HLS (most browsers aside from Desktop and Mobile Safari), then you will need to use a 3rd Party library in order to provide such support.
-
-When requesting to playback a stream using failover, you will need to provide an initialization configuration for each desired tech. To do so, provide a `rtc`, a `rtmp` and a `hls` configuration property within the configuraiton object passed through `init()` invocation:
-
-```js
-var config = {
-  rtcport: 5080,
-  rtmpport: 1935,
-  hlsport: 5080
-};
-var rtcConfig = Object.assign({}, config, {
-  protocol: 'ws',
-  port: config.rtcport,
-  subscriptionId: 'subscriber-' + instanceId,
-  streamName: config.stream1
-})
-var rtmpConfig = Object.assign({}, config, {
-  protocol: 'rtmp',
-  port: config.rtmpport,
-  streamName: config.stream1,
-  swf: 'lib/red5pro/red5pro-subscriber.swf',
-  swfobjectURL: 'lib/swfobject/swfobject.js',
-  productInstallURL: 'lib/swfobject/playerProductInstall.swf'
-})
-var hlsConfig = Object.assign({}, config, {
-  protocol: 'http',
-  port: config.hlsport,
-  streamName: config.stream1,
-  mimeType: 'application/x-mpegURL'
-})
-
-var subscriber = new red5pro.Red5ProSubscriber();
-subscriber.setPlaybackOrder(subscribeOrder)
-  .init({
-    rtc: rtcConfig,
-    rtmp: rtmpConfig,
-    hls: hlsConfig
-  })
-  .then(function (selectedSubscriber) {
-    // We have successfully found a playback tech from the list...
-  });
-```
-
-[index.js #97](index.js#L97)
-
-The `init` method of the `Red5ProSubscriber` returns a `Promise`-like object that will be resolved with the instantiated Subscriber implementation based on the subscriber order and browser support.
-
-You can determine the selected implementation by invoking `selectedSubscriber.getType()`.
-
-> Read more about configurations and their attributes from the [Red5 Pro HTML SDK Documentation](https://github.com/infrared5/red5pro-html-sdk#subscriber).
-
-### Subscribing
-
-The `init` method of the `Red5ProSubscriber` instance returns a `Promise`-object which, when resolved, relays the Subscriber instance determined from the failover. To start a subscribing session, call the `subscribe` method of the Subscriber resolved:
-
-```js
-subscriber.setPlaybackOrder(subscribeOrder)
-  .init({
-    rtc: rtcConfig,
-    rtmp: rtmpConfig,
-    hls: hlsConfig
-  })
-  .then(function (selectedSubscriber) {
-    return selectedSubscriber.subscribe();
-  })
-  .then(function () {
-    console.log('Successfully started a subscription session!');
-  })
-  .catch(function () {
-    console.error('Could not start a subscription session: ' + error);
-  })
-```
-
-[index.js #136](index.js#L136)
-
+Presumably it is due to having an additional media element (the added `audio` element) to a page in which another media element already exists and is unmuted and autoplay-ed.

--- a/src/page/test/subscribeVideoMute/index.html
+++ b/src/page/test/subscribeVideoMute/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html>
+  <head>
+    {{> meta title='Subscriber Video Mute Test'}}
+    {{> header-scripts}}
+    {{> header-stylesheets}}
+    <style>
+      .hidden {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      {{> version }}
+      {{> settings-link}}
+      {{> test-info testTitle='Subscriber Video Mute Test'}}
+      {{> status-field-subscriber}}
+      {{> statistics-field}}
+      <div class="centered">
+        <video id="red5pro-subscriber"
+                controls="controls" autoplay="autoplay" playsinline
+                class="red5pro-media red5pro-media-background"
+                width="640" height="480">
+        </video>
+      </div>
+      <div class="centered hidden">
+        <audio id="red5pro-audio-subscriber"
+               autoplay="autoplay" playsinline>
+        </video>
+      </div>
+    </div>
+    {{> body-scripts}}
+    {{> mobile-subscriber-util}}
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/src/page/test/subscribeVideoMute/index.js
+++ b/src/page/test/subscribeVideoMute/index.js
@@ -1,6 +1,11 @@
 (function(window, document, red5prosdk) {
   'use strict';
 
+  var isMoz = false;
+  if (window.adapter) {
+    isMoz = window.adapter.browserDetails.browser.toLowerCase() === 'firefox';
+  }
+
   var serverSettings = (function() {
     var settings = sessionStorage.getItem('r5proServerSettings');
     try {
@@ -175,6 +180,8 @@
   var streamingMode;
   var audioSubscriberDecoy;
   function handleStreamingModeMetadata (metadata) {
+    if (isMoz) return; // It works in Firefox!
+
     var volumeHandler = function (event) {
       if (audioSubscriberDecoy) {
         audioSubscriberDecoy.setVolume(event.data.volume)

--- a/src/page/test/subscribeVideoMute/index.js
+++ b/src/page/test/subscribeVideoMute/index.js
@@ -1,0 +1,241 @@
+(function(window, document, red5prosdk) {
+  'use strict';
+
+  var serverSettings = (function() {
+    var settings = sessionStorage.getItem('r5proServerSettings');
+    try {
+      return JSON.parse(settings);
+    }
+    catch (e) {
+      console.error('Could not read server settings from sessionstorage: ' + e.message);
+    }
+    return {};
+  })();
+
+  var configuration = (function () {
+    var conf = sessionStorage.getItem('r5proTestBed');
+    try {
+      return JSON.parse(conf);
+    }
+    catch (e) {
+      console.error('Could not read testbed configuration from sessionstorage: ' + e.message);
+    }
+    return {}
+  })();
+  red5prosdk.setLogLevel(configuration.verboseLogging ? red5prosdk.LOG_LEVELS.TRACE : red5prosdk.LOG_LEVELS.WARN);
+
+  var targetSubscriber;
+
+  var updateStatusFromEvent = window.red5proHandleSubscriberEvent; // defined in src/template/partial/status-field-subscriber.hbs
+  var instanceId = Math.floor(Math.random() * 0x10000).toString(16);
+  var streamTitle = document.getElementById('stream-title');
+  var statisticsField = document.getElementById('statistics-field');
+
+  var protocol = serverSettings.protocol;
+  var isSecure = protocol === 'https';
+
+  var bitrate = 0;
+  var packetsReceived = 0;
+  var frameWidth = 0;
+  var frameHeight = 0;
+  function updateStatistics (b, p, w, h) {
+    statisticsField.innerText = 'Bitrate: ' + Math.floor(b) + '. Packets Received: ' + p + '.' + ' Resolution: ' + w + ', ' + h + '.';
+  }
+
+  function onBitrateUpdate (b, p) {
+    bitrate = b;
+    packetsReceived = p;
+    updateStatistics(bitrate, packetsReceived, frameWidth, frameHeight);
+  }
+
+  function onResolutionUpdate (w, h) {
+    frameWidth = w;
+    frameHeight = h;
+    updateStatistics(bitrate, packetsReceived, frameWidth, frameHeight);
+  }
+
+  // Determines the ports and protocols based on being served over TLS.
+  function getSocketLocationFromProtocol () {
+    return !isSecure
+      ? {protocol: 'ws', port: serverSettings.wsport}
+      : {protocol: 'wss', port: serverSettings.wssport};
+  }
+
+  // Base configuration to extend in providing specific tech failover configurations.
+  var defaultConfiguration = (function(useVideo, useAudio) {
+    var c = {
+      protocol: getSocketLocationFromProtocol().protocol,
+      port: getSocketLocationFromProtocol().port
+    };
+    if (!useVideo) {
+      c.videoEncoding = red5prosdk.PlaybackVideoEncoder.NONE;
+    }
+    if (!useAudio) {
+      c.audioEncoding = red5prosdk.PlaybackAudioEncoder.NONE;
+    }
+    return c;
+  })(configuration.useVideo, configuration.useAudio);
+
+  // Local lifecycle notifications.
+  function onSubscriberEvent (event) {
+    if (event.type !== 'Subscribe.Time.Update') {
+      console.log('[Red5ProSubscriber] ' + event.type + '.');
+      updateStatusFromEvent(event);
+      if (event.type === 'Subscribe.Metadata') {
+        handleStreamingModeMetadata(event.data, targetSubscriber.getType());
+      }
+    }
+  }
+  function onSubscribeFail (message) {
+    console.error('[Red5ProSubsriber] Subscribe Error :: ' + message);
+  }
+  function onSubscribeSuccess (subscriber) {
+    console.log('[Red5ProSubsriber] Subscribe Complete.');
+    if (window.exposeSubscriberGlobally) {
+      window.exposeSubscriberGlobally(subscriber);
+    }
+    if (subscriber.getType().toLowerCase() === 'rtc') {
+      try {
+        window.trackBitrate(subscriber.getPeerConnection(), onBitrateUpdate, onResolutionUpdate, true);
+      }
+      catch (e) {
+        //
+      }
+    }
+  }
+  function onUnsubscribeFail (message) {
+    console.error('[Red5ProSubsriber] Unsubscribe Error :: ' + message);
+  }
+  function onUnsubscribeSuccess () {
+    console.log('[Red5ProSubsriber] Unsubscribe Complete.');
+  }
+
+  function getAuthenticationParams () {
+    var auth = configuration.authentication;
+    return auth && auth.enabled
+      ? {
+        connectionParams: {
+          username: auth.username,
+          password: auth.password
+        }
+      }
+      : {};
+  }
+
+  // Request to unsubscribe.
+  function unsubscribe () {
+    return new Promise(function(resolve, reject) {
+      var subscriber = targetSubscriber
+      subscriber.unsubscribe()
+        .then(function () {
+          targetSubscriber.off('*', onSubscriberEvent);
+          targetSubscriber = undefined;
+          onUnsubscribeSuccess();
+          resolve();
+        })
+        .catch(function (error) {
+          var jsonError = typeof error === 'string' ? error : JSON.stringify(error, null, 2);
+          onUnsubscribeFail(jsonError);
+          reject(error);
+        });
+    });
+  }
+
+  // Define tech spefific configurations for each failover item.
+  var config = Object.assign({},
+    configuration,
+    defaultConfiguration,
+    getAuthenticationParams());
+  var rtcConfig = Object.assign({}, config, {
+    protocol: getSocketLocationFromProtocol().protocol,
+    port: getSocketLocationFromProtocol().port,
+    subscriptionId: 'subscriber-' + instanceId,
+    streamName: config.stream1,
+  })
+
+  // Request to initialization and start subscribing through failover support.
+  var subscriber = new red5prosdk.RTCSubscriber()
+  subscriber.init(rtcConfig)
+    .then(function (subscriberImpl) {
+      streamTitle.innerText = configuration.stream1;
+      targetSubscriber = subscriberImpl
+      // Subscribe to events.
+      targetSubscriber.on('*', onSubscriberEvent);
+      return targetSubscriber.subscribe()
+    })
+    .then(function () {
+      onSubscribeSuccess(targetSubscriber);
+    })
+    .catch(function (error) {
+      var jsonError = typeof error === 'string' ? error : JSON.stringify(error, null, 2);
+      console.error('[Red5ProSubscriber] :: Error in subscribing - ' + jsonError);
+      onSubscribeFail(jsonError);
+    });
+
+  var streamingMode;
+  var audioSubscriberDecoy;
+  function handleStreamingModeMetadata (metadata) {
+    var volumeHandler = function (event) {
+      if (audioSubscriberDecoy) {
+        audioSubscriberDecoy.setVolume(event.data.volume)
+      }
+    }
+    if (streamingMode !== metadata.streamingMode) {
+      var previousStreamingMode = streamingMode;
+      streamingMode = metadata.streamingMode;
+      if (streamingMode === 'Audio' && previousStreamingMode === undefined) {
+        // Then, we have started playback of an Audio only stream because
+        // the broadcaster has turned off their Camera stream.
+        // There is a bug in some browsers that will not allow A/V bundled streams
+        // to playback JUST audio on initial subscription in a <video> element; they only allow <audio>.
+        addAudioSubscriberDecoy(function (subscriber) {
+          audioSubscriberDecoy = subscriber;
+          targetSubscriber.on('Subscribe.Volume.Change', volumeHandler)
+        });
+      } else if (audioSubscriberDecoy) {
+        removeAudioSubscriberDecoy(audioSubscriberDecoy);
+        targetSubscriber.off('Subscribe.Volume.Change', volumeHandler)
+        audioSubscriberDecoy = undefined;
+      }
+    }
+  }
+
+  function addAudioSubscriberDecoy (cb) {
+    var extension = {
+      mediaElementId: 'red5pro-audio-subscriber',
+      subscriptionId: 'subscriber-' + Math.floor(Math.random() * 0x10000).toString(16)
+    };
+    new red5prosdk.RTCSubscriber()
+      .init(Object.assign(rtcConfig, extension))
+      .then(function (aSubscriber) {
+        cb(aSubscriber)
+        return aSubscriber.subscribe();
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  }
+
+  function removeAudioSubscriberDecoy (decoy) {
+    decoy.unsubscribe();
+  }
+
+  // Clean up.
+  var shuttingDown = false;
+  function shutdown() {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    function clearRefs () {
+      if (targetSubscriber) {
+        targetSubscriber.off('*', onSubscriberEvent);
+      }
+      targetSubscriber = undefined;
+    }
+    unsubscribe().then(clearRefs).catch(clearRefs);
+    window.untrackBitrate();
+  }
+  window.addEventListener('pagehide', shutdown);
+  window.addEventListener('beforeunload', shutdown);
+
+})(this, document, window.red5prosdk);
+

--- a/src/page/testbed-menu.html
+++ b/src/page/testbed-menu.html
@@ -47,6 +47,7 @@
             <li><a href="test/subscribeRetryOnInvalidName">Subscribe - Retry On Connection (WebRTC)</a></li>
             <li><a href="test/subscribeScreenShare">Subscribe - ScreenShare (WebRTC)</a></li>
             <li><a href="test/subscribeCall">Subscribe - Server Call (WebRTC)</a></li>
+            <li><a href="test/subscribeVideoMute">Subscribe - Video Mute (WebRTC)</a></li>
             <li><a href="test/subscribeSharedObject">Subscribe - Shared Object</a></li>
             <li><a href="test/playbackVOD">Playback - VOD</a></li>
             <li><a href="test/subscribevp8">Subscribe - VP8</a></li>


### PR DESCRIPTION
* Added test `Subscribe - Video Mute (WebRTC)`
* To address issue fo no audio playback when subscribing to video with video "muted"

The test checks if browser is *not* Firefox (because, of course, it works in Firefox) and if so, adds an additional `audio` element to the page to playback audio _until_ video is unmuted.

Of Note:

1. You have to click on the test in the test list to navigate to it, otherwise `autoplay` restrictions kill the audio playback.
2. Safari still doesn't like it - most likely because there are 2 media elements both unmuted on the page.