### PR TITLE
fix for camera select clearing on publisher source.

### DIFF
--- a/src/page/sm-test/publishStreamManagerProxyCamera/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyCamera/index.js
@@ -274,6 +274,17 @@
         resolve();
         return;
       }
+      var stream = publisher.getMediaStream();
+      if (stream) {
+        var i;
+        var track;
+        var tracks = stream.getTracks();
+        for (i = 0; i < tracks.length; i++) {
+          track = tracks[i];
+          track.stop();
+        }
+      }
+      document.getElementById('red5pro-publisher').srcObject = null;
       publisher.unpublish()
         .then(function () {
           onUnpublishSuccess();

--- a/src/page/test/publishCameraSource/index.js
+++ b/src/page/test/publishCameraSource/index.js
@@ -189,6 +189,16 @@
   function unpublish () {
     return new Promise(function (resolve, reject) {
       if (targetPublisher) {
+        var stream = targetPublisher.getMediaStream();
+        if (stream) {
+          var i;
+          var track;
+          var tracks = stream.getTracks();
+          for (i = 0; i < tracks.length; i++) {
+            track = tracks[i];
+            track.stop();
+          }
+        }
         targetPublisher.unpublish()
           .then(function () {
             onUnpublishSuccess();


### PR DESCRIPTION
* clear out mediatracks on unpublish in camera select examples.