### PR TITLE
better camera management on custom settings publisher test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red5pro-html-sdk-testbed",
-  "version": "6.0.0-RC7",
+  "version": "6.0.0-RC8",
   "description": "Testbed examples for Red5 Pro HTML SDK",
   "main": "src/js/index.js",
   "repository": {

--- a/src/template/partial/meta.hbs
+++ b/src/template/partial/meta.hbs
@@ -1,3 +1,3 @@
 <title>{{ title }}</title>
-<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
 <meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport">


### PR DESCRIPTION
Tests:

* `Publish - Custom Settings (WebRTC)`
* `Publish - Stream Manager Proxy w/ Settings (RTC)`

---

Establishing initial camera selection using only `exact:deviceId` and clearing each preview of video tracks with a `200ms` delay in re-establishment of preview.