### PR TITLE
Bug/sm port rpro 7281

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red5pro-html-sdk-testbed",
-  "version": "6.2.0-RC3",
+  "version": "6.2.0-RC4",
   "description": "Testbed examples for Red5 Pro HTML SDK",
   "main": "src/js/index.js",
   "repository": {

--- a/src/page/sm-test/TwoWayStreamManagerProxy/index.js
+++ b/src/page/sm-test/TwoWayStreamManagerProxy/index.js
@@ -213,9 +213,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestOrigin(streamName, action){
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '2.0';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=' + action;
     return new Promise(function (resolve, reject) {
@@ -306,9 +305,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
   function beginStreamListCall () {
     var host = configuration.host;
-    var port = serverSettings.hlsport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var url = baseUrl + '/streammanager/api/2.0/event/list';
     fetch(url)
       .then(function (res) {

--- a/src/page/sm-test/playbackVODStreamManager/index.js
+++ b/src/page/sm-test/playbackVODStreamManager/index.js
@@ -182,9 +182,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestPlaylist (configuration, vod) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/media/' + app + '/playlists';
     return new Promise(function (resolve, reject) {
@@ -232,9 +231,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration, vod) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/media/' + app + '/' + vod;
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/playbackVODStreamManagerList/index.js
+++ b/src/page/sm-test/playbackVODStreamManagerList/index.js
@@ -184,9 +184,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestVOD (configuration, vodType /* mediafiles | playlists */) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/media/' + app + '/' + vodType;
     return new Promise(function (resolve, reject) {
@@ -222,9 +221,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration, vod) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/media/' + app + '/' + vod;
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManager/index.js
+++ b/src/page/sm-test/publishStreamManager/index.js
@@ -137,8 +137,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var app = configuration.app;
     var streamName = configuration.stream1;
     var port = serverSettings.httpport;
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProvisionForm/index.js
+++ b/src/page/sm-test/publishStreamManagerProvisionForm/index.js
@@ -71,7 +71,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   streamTitle.innerText = configuration.stream1;
 
   var protocol = serverSettings.protocol;
-  var isSecure = protocol == 'https';
   var accessToken = configuration.streamManagerAccessToken;
   var authName = '';
   var authPass = '';
@@ -94,9 +93,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/admin/event/meta/' + app + '/' + streamName + '?accessToken=' + accessToken;
     return new Promise(function (resolve, reject) {
@@ -133,9 +131,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxy/index.js
+++ b/src/page/sm-test/publishStreamManagerProxy/index.js
@@ -151,9 +151,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxyCamera/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyCamera/index.js
@@ -198,9 +198,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxyMultiOriginRequest/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyMultiOriginRequest/index.js
@@ -150,9 +150,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast&endpoints=2';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxyMultiOriginStrictRequest/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyMultiOriginStrictRequest/index.js
@@ -150,9 +150,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxyRecord/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyRecord/index.js
@@ -150,9 +150,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxyRegionRequest/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyRegionRequest/index.js
@@ -150,9 +150,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var region = configuration.streamManagerRegion;
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast' + '&region=' + region;

--- a/src/page/sm-test/publishStreamManagerProxyRegionStrictRequest/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyRegionStrictRequest/index.js
@@ -150,9 +150,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxyRoundTripAuth/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyRoundTripAuth/index.js
@@ -145,9 +145,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.0';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxyScreenShare/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyScreenShare/index.js
@@ -188,9 +188,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxySettings/index.js
+++ b/src/page/sm-test/publishStreamManagerProxySettings/index.js
@@ -324,9 +324,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxySettings/index.js
+++ b/src/page/sm-test/publishStreamManagerProxySettings/index.js
@@ -269,34 +269,41 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     cameraSelect.innerHTML = options.join(' ');
   }
 
-  function establishInitialStream () {
-    var stream;
-    var constraints = getUserMediaConfiguration();
+  function clearEstablishedStream () {
     var pubElement = document.getElementById('red5pro-publisher');
     if (pubElement.srcObject) {
       pubElement.srcObject.getTracks().forEach(function (track) {
         track.stop();
       });
+      return true;
     }
-    if (configuration.useVideo) {
-      delete constraints.video.frameRate;
-    }
-    navigator.mediaDevices.getUserMedia(constraints)
-      .then(function (mediastream) {
-        stream = mediastream;
-        return navigator.mediaDevices.enumerateDevices()
-      })
-      .then(function (devices) {
-        listDevices(devices);
-        stream.getVideoTracks().forEach(function (track) {
-          cameraSelect.value = track.getSettings().deviceId;
+    return false;
+  }
+
+  function establishInitialStream (deviceId) {
+    var stream;
+    var constraints = {audio:false, video: (deviceId ? { deviceId: {exact: deviceId} } : true) };
+    var pubElement = document.getElementById('red5pro-publisher');
+    var delay = clearEstablishedStream() ? 200 : 0;
+    var t = setTimeout(function () {
+      clearTimeout(t);
+      navigator.mediaDevices.getUserMedia(constraints)
+        .then(function (mediastream) {
+          stream = mediastream;
+          return navigator.mediaDevices.enumerateDevices()
+        })
+        .then(function (devices) {
+          listDevices(devices);
+          stream.getVideoTracks().forEach(function (track) {
+            cameraSelect.value = track.getSettings().deviceId;
+          });
+          pubElement.srcObject = stream;
+        })
+        .catch(function (error) {
+          console.error(error);
+          showConstraintError(error.message, error.constraint || 'N/A');
         });
-        document.getElementById('red5pro-publisher').srcObject = stream;
-      })
-      .catch(function (error) {
-        console.error(error);
-        showConstraintError(error.message, error.constraint || 'N/A');
-      });
+    }, delay);
   }
 
   function onCameraSelect () {
@@ -440,24 +447,27 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   var retryCount = 0;
   var retryLimit = 3;
   function respondToOrigin (response) {
-    determinePublisher(response)
-      .then(function (publisherImpl) {
-        streamTitle.innerText = configuration.stream1;
-        targetPublisher = publisherImpl;
-        return targetPublisher.publish()
-      })
-      .then(function () {
-        onPublishSuccess(targetPublisher);
-      })
-      .catch(function (error) {
-        var jsonError = typeof error === 'string' ? error : JSON.stringify(error, null, 2);
-        console.error('[Red5ProPublisher] :: Error in access of Origin IP: ' + jsonError);
-        updateStatusFromEvent({
-          type: red5prosdk.PublisherEventTypes.CONNECT_FAILURE
+    var delay = clearEstablishedStream() ? 200 : 0;
+    var t = setTimeout(function (){
+      clearTimeout(t);
+      determinePublisher(response)
+        .then(function (publisherImpl) {
+          streamTitle.innerText = configuration.stream1;
+          targetPublisher = publisherImpl;
+          return targetPublisher.publish()
+        })
+        .then(function () {
+          onPublishSuccess(targetPublisher);
+        })
+        .catch(function (error) {
+          var jsonError = typeof error === 'string' ? error : JSON.stringify(error, null, 2);
+          console.error('[Red5ProPublisher] :: Error in access of Origin IP: ' + jsonError);
+          updateStatusFromEvent({
+            type: red5prosdk.PublisherEventTypes.CONNECT_FAILURE
+          });
+          onPublishFail(jsonError);
         });
-        onPublishFail(jsonError);
-      });
-
+    }, delay);
   }
 
   function respondToOriginFailure (error) {
@@ -488,7 +498,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   }
 
   function restart() {
-    establishInitialStream();
+    establishInitialStream((cameraSelect.value && cameraSelect.value.length > 0) ? cameraSelect.value : undefined);
   }
 
   navigator.mediaDevices.enumerateDevices()

--- a/src/page/sm-test/publishStreamManagerProxyTranscoderPOST/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyTranscoderPOST/index.js
@@ -204,9 +204,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/admin/event/meta/' + app + '/' + streamName + '?accessToken=' + accessToken;
     return new Promise(function (resolve, reject) {
@@ -241,9 +240,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var streamName = configuration.stream1;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=broadcast&transcode=true';
       return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/publishStreamManagerProxyValidation/index.js
+++ b/src/page/sm-test/publishStreamManagerProxyValidation/index.js
@@ -127,7 +127,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     action: 'broadcast',
     protocol: protocol,
     host: configuration.host,
-    port: (isSecure || proxyLocal) ? undefined : serverSettings.httpport.toString(),
+    port: serverSettings.httpport,
     scope: configuration.app,
     streamName: configuration.stream1,
     apiVersion: configuration.streamManagerAPI || '3.1',

--- a/src/page/sm-test/subscribeStreamManager/index.js
+++ b/src/page/sm-test/subscribeStreamManager/index.js
@@ -174,8 +174,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var host = configuration.host;
     var app = configuration.app;
     var port = serverSettings.httpport;
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var streamName = configuration.stream1;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';

--- a/src/page/sm-test/subscribeStreamManagerProxy/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxy/index.js
@@ -176,9 +176,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = proxyLocal ? '' : serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure || proxyLocal ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var streamName = configuration.stream1;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';

--- a/src/page/sm-test/subscribeStreamManagerProxyRegionRequest/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyRegionRequest/index.js
@@ -176,9 +176,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = proxyLocal ? '' : serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure || proxyLocal ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var streamName = configuration.stream1;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var region = configuration.streamManagerRegion;

--- a/src/page/sm-test/subscribeStreamManagerProxyRoundTripAuth/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyRoundTripAuth/index.js
@@ -173,9 +173,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var streamName = configuration.stream1;
     var apiVersion = configuration.streamManagerAPI || '3.0';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';

--- a/src/page/sm-test/subscribeStreamManagerProxyScreenShare/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyScreenShare/index.js
@@ -92,9 +92,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = proxyLocal ? '' : serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure || proxyLocal ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var streamName = configuration.stream1;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';

--- a/src/page/sm-test/subscribeStreamManagerProxyTranscoderHLS/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyTranscoderHLS/index.js
@@ -122,9 +122,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration, streamName) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
       return new Promise(function (resolve, reject) {
@@ -152,9 +151,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestABRSettings (streamName) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/admin/event/meta/' + app + '/' + streamName + '?action=subscribe&accessToken=' + configuration.streamManagerAccessToken;
     return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/subscribeStreamManagerProxyTranscoderRTC/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyTranscoderRTC/index.js
@@ -177,9 +177,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration, streamName) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
       return new Promise(function (resolve, reject) {
@@ -207,9 +206,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestABRSettings (streamName) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/admin/event/meta/' + app + '/' + streamName + '?action=subscribe&accessToken=' + configuration.streamManagerAccessToken;
     return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/subscribeStreamManagerProxyTranscoderRTMP/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyTranscoderRTMP/index.js
@@ -173,9 +173,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration, streamName) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
       return new Promise(function (resolve, reject) {
@@ -203,9 +202,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestABRSettings (streamName) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/admin/event/meta/' + app + '/' + streamName + '?action=subscribe&accessToken=' + configuration.streamManagerAccessToken;
     return new Promise(function (resolve, reject) {

--- a/src/page/sm-test/subscribeStreamManagerProxyVP8/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyVP8/index.js
@@ -136,9 +136,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   function requestEdge (configuration) {
     var host = configuration.host;
     var app = configuration.app;
-    var port = serverSettings.httpport.toString();
-    var portURI = (port.length > 0 ? ':' + port : '');
-    var baseUrl = isSecure ? protocol + '://' + host : protocol + '://' + host + portURI;
+    var port = serverSettings.httpport;
+    var baseUrl = protocol + '://' + host + ':' + port;
     var streamName = configuration.stream1;
     var apiVersion = configuration.streamManagerAPI || '3.1';
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';

--- a/src/page/sm-test/subscribeStreamManagerProxyValidation/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyValidation/index.js
@@ -163,7 +163,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     action: 'subscribe',
     protocol: protocol,
     host: configuration.host,
-    port: isSecure || proxyLocal ? undefined : serverSettings.httpport.toString(),
+    port: serverSettings.httpport,
     scope: configuration.app,
     streamName: configuration.stream1,
     apiVersion: configuration.streamManagerAPI || '3.1',

--- a/src/page/test/subscribeHLS/index.js
+++ b/src/page/test/subscribeHLS/index.js
@@ -83,7 +83,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       updateStatusFromEvent(event);
     }
     if (event.type === 'Subscribe.VideoDimensions.Change') {
-      onResolutionUpdate(event.data.width, event.data.height);
+      //onResolutionUpdate(event.data.width, event.data.height);
     }
   }
   function onSubscribeFail (message) {


### PR DESCRIPTION
* The stream manager tests previously assumed that if you were accessing the testbed over https, that all SM API requests were to be made on port `443`.
* It now uses the current port used on which the testbed is served.
* The reason being that the testbed and streammanager can only be hosted on the same port, and a user is most likely accessing the API using the testbed