### PR TITLE
Adding `strict=true` to query params

### DIFF
--- a/src/page/sm-test/TwoWayStreamManagerProxy/index.js
+++ b/src/page/sm-test/TwoWayStreamManagerProxy/index.js
@@ -220,7 +220,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=' + action;
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
     return new Promise(function (resolve, reject) {
       fetch(url)

--- a/src/page/sm-test/subscribeBackupStreamSwitchStreammanager/index.js
+++ b/src/page/sm-test/subscribeBackupStreamSwitchStreammanager/index.js
@@ -312,7 +312,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var region = getRegionIfDefined();
     var url = 'https://' + smHost + '/streammanager/api/' + version + '/event/' + smApp + '/' + streamName + '?action=subscribe&endpoints=' + amount;
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
     return new Promise(function (resolve, reject) { // eslint-disable-line no-unused-vars
       fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxy/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxy/index.js
@@ -192,7 +192,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
     return new Promise(function (resolve, reject) {
       fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyAMFMetadata/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyAMFMetadata/index.js
@@ -203,7 +203,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
     return new Promise(function (resolve, reject) {
       fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyDataChannel/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyDataChannel/index.js
@@ -327,7 +327,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
     return new Promise(function (resolve, reject) {
       fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyInterstitial/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyInterstitial/index.js
@@ -277,7 +277,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
       return new Promise(function (resolve, reject) {
         fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyMute/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyMute/index.js
@@ -211,7 +211,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
       return new Promise(function (resolve, reject) {
         fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyReconnect/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyReconnect/index.js
@@ -222,7 +222,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
       return new Promise(function (resolve, reject) {
         fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyRoundTripAuth/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyRoundTripAuth/index.js
@@ -188,7 +188,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
       return new Promise(function (resolve, reject) {
         fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyScreenShare/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyScreenShare/index.js
@@ -107,7 +107,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
       return new Promise(function (resolve, reject) {
         fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxySwitch/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxySwitch/index.js
@@ -207,7 +207,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
       return new Promise(function (resolve, reject) {
         fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyTranscoderHLS/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyTranscoderHLS/index.js
@@ -136,7 +136,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
       return new Promise(function (resolve, reject) {
         fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyTranscoderRTC/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyTranscoderRTC/index.js
@@ -198,7 +198,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
       return new Promise(function (resolve, reject) {
         fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyVP8/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyVP8/index.js
@@ -152,7 +152,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var url = baseUrl + '/streammanager/api/' + apiVersion + '/event/' + app + '/' + streamName + '?action=subscribe';
     var region = getRegionIfDefined();
     if (region) {
-      url += '&region=' + region;
+      url += '&region=' + region + '&strict=true';
     }
       return new Promise(function (resolve, reject) {
         fetch(url)

--- a/src/page/sm-test/subscribeStreamManagerProxyValidation/index.js
+++ b/src/page/sm-test/subscribeStreamManagerProxyValidation/index.js
@@ -153,6 +153,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     var region = getRegionIfDefined();
     if (region) {
       kvObject.region = region;
+      kvObject.strict = 'true';
     }
     var nodes = validationForm.childNodes;
     var i = 0, length = nodes.length;


### PR DESCRIPTION
- On all Subscriber Stream Manager Tests when region field value is present in Settings
- Fixes RED5DEV-265
- Setting the `region` query param alone is currently not enough for the Stream Manager to return payload specified in the region. An addition `strict` query param will force the Stream Manager to return the
specified node payload for that region.