### PR TITLE
fix: style override in HTML for modal unhide.

### DIFF
--- a/src/page/sm-test/publishStreamManagerProxyAudioSettings/index.html
+++ b/src/page/sm-test/publishStreamManagerProxyAudioSettings/index.html
@@ -82,5 +82,10 @@
     {{> sm-scripts}}
     <script src="index.js"></script>
     <link rel="stylesheet" href="../../css/modal.css" />
+    <style>
+      .modal {
+        display: unset!important;
+      }
+    </style>
   </body>
 </html>

--- a/src/page/sm-test/publishStreamManagerProxyDataChannel/index.html
+++ b/src/page/sm-test/publishStreamManagerProxyDataChannel/index.html
@@ -17,6 +17,11 @@
       }
     </style>
     <link rel="stylesheet" href="../../css/modal.css" />
+    <style>
+      .modal {
+        display: unset!important;
+      }
+    </style>
     <!--    <script src="../../script/mock-fetch.js"></script>-->
   </head>
   <body>

--- a/src/page/sm-test/subscribeStreamManagerProxyDataChannel/index.html
+++ b/src/page/sm-test/subscribeStreamManagerProxyDataChannel/index.html
@@ -7,6 +7,11 @@
     {{> header-stylesheets}}
     <!--<script src="../../script/mock-fetch.js"></script>-->
     <link rel="stylesheet" href="../../css/modal.css" />
+    <style>
+      .modal {
+        display: unset!important;
+      }
+    </style>
   </head>
   <body>
     {{> top-bar }}

--- a/src/page/test/publishAudioCustomSettingsWebRTC/index.html
+++ b/src/page/test/publishAudioCustomSettingsWebRTC/index.html
@@ -78,5 +78,10 @@
     {{> body-scripts}}
     <script src="index.js"></script>
     <link rel="stylesheet" href="../../css/modal.css" />
+    <style>
+      .modal {
+        display: unset!important;
+      }
+    </style>
   </body>
 </html>

--- a/src/page/test/publishAvailableHDSettings/index.html
+++ b/src/page/test/publishAvailableHDSettings/index.html
@@ -78,5 +78,10 @@
     {{> body-scripts}}
     <script src="index.js"></script>
     <link rel="stylesheet" href="../../css/modal.css" />
+    <style>
+      .modal {
+        display: unset!important;
+      }
+    </style>
   </body>
 </html>

--- a/src/page/test/publishCustomSettingsWebRTC/index.html
+++ b/src/page/test/publishCustomSettingsWebRTC/index.html
@@ -70,5 +70,10 @@
     {{> body-scripts}}
     <script src="index.js"></script>
     <link rel="stylesheet" href="../../css/modal.css" />
+    <style>
+      .modal {
+        display: unset!important;
+      }
+    </style>
   </body>
 </html>

--- a/src/page/test/publishDataChannel/index.html
+++ b/src/page/test/publishDataChannel/index.html
@@ -17,6 +17,11 @@
       }
     </style>
     <link rel="stylesheet" href="../../css/modal.css" />
+    <style>
+      .modal {
+        display: unset!important;
+      }
+    </style>
   </head>
   <body>
     {{> top-bar }}

--- a/src/template/partial/mobile-subscriber-util.hbs
+++ b/src/template/partial/mobile-subscriber-util.hbs
@@ -1,4 +1,9 @@
 <link rel="stylesheet" href="../../css/modal.css" />
+<style>
+  .modal {
+    display: unset!important;
+  }
+</style>
 <script>
   (function (red5prosdk) {
     /**


### PR DESCRIPTION
No idea why the build CSS is not having the declaration that is defined in the `modal.css` file.